### PR TITLE
Add proxy headers to FastAPI

### DIFF
--- a/authentication/Dockerfile
+++ b/authentication/Dockerfile
@@ -10,4 +10,4 @@ COPY database /app/database
 COPY schemas /app/schemas
 
 
-CMD ["python3", "-m", "uvicorn", "authentication.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python3", "-m", "uvicorn", "authentication.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]

--- a/frontend/src/features/transactions/wallet/WalletTransactionsGrid.tsx
+++ b/frontend/src/features/transactions/wallet/WalletTransactionsGrid.tsx
@@ -9,7 +9,6 @@ import {
 
 export const WalletTransactionsGrid = () => {
   const transactions = useWalletTransactions();
-  console.log(transactions.data);
 
   const columns: GridColDef<WalletTransaction>[] = [
     { field: 'stock_tx_id', headerName: 'Stock Tx Id', flex: 10 },

--- a/matching-engine/Dockerfile
+++ b/matching-engine/Dockerfile
@@ -10,4 +10,4 @@ COPY database /app/database
 COPY schemas /app/schemas
 
 
-CMD ["python3", "-m", "uvicorn", "matching-engine.app.main:app", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["python3", "-m", "uvicorn", "matching-engine.app.main:app", "--host", "0.0.0.0", "--port", "8001", "--proxy-headers"]

--- a/transaction/Dockerfile
+++ b/transaction/Dockerfile
@@ -10,4 +10,4 @@ COPY database /app/database
 COPY schemas /app/schemas
 
 
-CMD ["python3", "-m", "uvicorn", "transaction.main:app", "--host", "0.0.0.0", "--port", "8002"]
+CMD ["python3", "-m", "uvicorn", "transaction.main:app", "--host", "0.0.0.0", "--port", "8002", "--proxy-headers"]


### PR DESCRIPTION
This PR adds the --proxy-headers flag to FastAPI, per the documentation 

[https://fastapi.tiangolo.com/deployment/docker/?h=proxy#behind-a-tls-termination-proxy](url)