### PR TITLE
Downgrade MUI DataGrid to 7.25

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.1",
         "@mui/material": "^6.4.1",
-        "@mui/x-data-grid": "^7.26.0",
+        "@mui/x-data-grid": "7.25.0",
         "@tanstack/react-query": "^4.36.1",
         "axios": "^1.7.9",
         "install": "^0.13.0",
@@ -1317,18 +1317,17 @@
       }
     },
     "node_modules/@mui/x-data-grid": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.26.0.tgz",
-      "integrity": "sha512-9RNQeT2OL6jBOCE0MSUH11ol3fV5Zs9MkGxUIAGXcy/Fui0rZRNFO1yLmWDZU5yvskiNmUZJHWV/qXh++ZFarA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.25.0.tgz",
+      "integrity": "sha512-e9ZLbCgnDiADFiDyXo91ucZFHEMkKBNpwpkaTq5KohzefJfMpMQjTEbJeueSfBG2G1Q1Am2TPeBqrNeReIA7RQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0",
-        "@mui/x-internals": "7.26.0",
+        "@mui/x-internals": "7.25.0",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.0.0"
+        "reselect": "^5.1.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1355,9 +1354,9 @@
       }
     },
     "node_modules/@mui/x-internals": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.26.0.tgz",
-      "integrity": "sha512-VxTCYQcZ02d3190pdvys2TDg9pgbvewAVakEopiOgReKAUhLdRlgGJHcOA/eAuGLyK1YIo26A6Ow6ZKlSRLwMg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.25.0.tgz",
+      "integrity": "sha512-tBUN54YznAkmtCIRAOl35Kgl0MjFDIjUbzIrbWRgVSIR3QJ8bXnVSkiRBi+P91SZEl9+ZW0rDj+osq7xFJV0kg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.4.1",
     "@mui/material": "^6.4.1",
-    "@mui/x-data-grid": "^7.26.0",
+    "@mui/x-data-grid": "7.25.0",
     "@tanstack/react-query": "^4.36.1",
     "axios": "^1.7.9",
     "install": "^0.13.0",


### PR DESCRIPTION
This PR downgrades the MUI `DataGrid` component from ^7.26 to version 7.25. There is a bug in 7.26 that causes an error. The suggested fix for now is to downgrade to version 7.25


[https://github.com/mui/mui-x/pull/16488](url)